### PR TITLE
Rename working-dir to directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All parameters are optional, with no parameters provided, these defaults are use
 - token - if you want to push to a different repository you need to provide your own token, otherwise you can leave it
 to the default value which is provided by GitHub Actions and works for the same repository
 - force - you can specify true to perform force push, default is to not use force push
-- working-dir - the working directory to do the commands in, default is `.` (current directory)
+- directory - the working directory to do the commands in, default is `.` (current directory)
 
 ## Full reference
 

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ inputs:
     description: Whether to perform force push
     required: true
     default: '0'
-  working-dir:
+  directory:
     description: The working directory that will be used for git commands
     required: true
     default: '.'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,12 @@ echo "  password $INPUT_TOKEN" >> "$HOME/.netrc"
 git config user.email "$INPUT_EMAIL"
 git config user.name "$INPUT_NAME"
 
+echo "---------------------"
+echo "environment variables"
+echo "---------------------"
+printenv
+echo "---------------------"
+
 cd "$INPUT_WORKING_DIR" || exit 1
 
 # shellcheck disable=SC2086

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+cd "$INPUT_DIRECTORY" || exit 1
+
 CURRENT_BRANCH=$(echo "$GITHUB_REF" | sed "s@refs/heads/@@")
 TARGET_BRANCH=$INPUT_BRANCH
 case $TARGET_BRANCH in "refs/heads/"*)
@@ -20,8 +22,6 @@ echo "  password $INPUT_TOKEN" >> "$HOME/.netrc"
 
 git config user.email "$INPUT_EMAIL"
 git config user.name "$INPUT_NAME"
-
-cd "$INPUT_DIRECTORY" || exit 1
 
 # shellcheck disable=SC2086
 git add $INPUT_FILES -v

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ echo "  password $INPUT_TOKEN" >> "$HOME/.netrc"
 git config user.email "$INPUT_EMAIL"
 git config user.name "$INPUT_NAME"
 
-cd "$INPUT_WORKING-DIR" || exit 1
+cd "$INPUT_DIRECTORY" || exit 1
 
 # shellcheck disable=SC2086
 git add $INPUT_FILES -v

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,13 +21,7 @@ echo "  password $INPUT_TOKEN" >> "$HOME/.netrc"
 git config user.email "$INPUT_EMAIL"
 git config user.name "$INPUT_NAME"
 
-echo "---------------------"
-echo "environment variables"
-echo "---------------------"
-printenv
-echo "---------------------"
-
-cd "$INPUT_WORKING_DIR" || exit 1
+cd "$INPUT_WORKING-DIR" || exit 1
 
 # shellcheck disable=SC2086
 git add $INPUT_FILES -v


### PR DESCRIPTION
There were a few of issues regarding `working-dir`:
- GitHub Actions infrastructure creates an environment variable `$INPUT_WORKING-DIR` instead of `$INPUT_WORKING_DIR` (I honestly think this should ideally be fixed in GitHub Actions infrastructure)
- There are ways to work around it, but as far as I understand hyphen is not a supported character in environment variables in various shells, so I renamed the parameter.
- I also moved the `cd` command to top as git commands require to be in a git tracked working directory.

I hope this is an acceptable change :)