### PR TITLE
Support multi-repo checkouts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-git config --global --add safe.directory /github/workspace
-
 cd "$INPUT_DIRECTORY" || exit 1
+
+git config --global --add safe.directory "$INPUT_DIRECTORY"
 
 CURRENT_BRANCH=$(echo "$GITHUB_REF" | sed "s@refs/heads/@@")
 TARGET_BRANCH=$INPUT_BRANCH


### PR DESCRIPTION
Adding `/github/workspace` as a safe directory doesn't cut it for multi repo checkouts even though the repositories are checked out to its subdirectories. Given that commit action is working in the `$INPUT_DIRECTORY` always, I think my proposed solution should work.

I have tested with multiple repo checkout: https://github.com/microsoftgraph/msgraph-sdk-raptor/runs/6202062937?check_suite_focus=true

I haven't tested with a single repo checkout.

Related issue on our repository:
- https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/997